### PR TITLE
small fixes for memory initialization

### DIFF
--- a/smartcard.c
+++ b/smartcard.c
@@ -348,7 +348,7 @@ static int cardmanager_check_pcscd_is_running(void)
 /* this should not be here but in pcsc_driver.c */
 int cardmanager_search_pcsc_readers(cardmanager_t *cm)
 {
-  DWORD dwReaders;
+  DWORD dwReaders = 0;
   char *p;
   LONG hcontext = 0;
   long status;

--- a/ui/gtk/gui_cardview.c
+++ b/ui/gtk/gui_cardview.c
@@ -431,7 +431,7 @@ static GtkWidget *script_info_add(const char *path, const char *fname)
         si = (ScriptInfo *)g_malloc0(sizeof(ScriptInfo));
         si->script_file = strdup(fname);
 
-        rtrim(line);
+        //rtrim(line); uninitialized yet
 
         for (i=0; i<30; i++)
         {


### PR DESCRIPTION
To supress valgrind warnings and focus on real memory management problems.
