### PR TITLE
Create tar.gz in a reproducible way

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -97,7 +97,7 @@ dist-hook:
 
 dot_cardpeek.tar.gz:    dot_cardpeek_dir	
 			@echo "  TAR      $<"
-			$(AM_V_at)tar -c -z -f dot_cardpeek.tar.gz --directory $(srcdir)/dot_cardpeek_dir --exclude=.svn --exclude='\._*' .
+			$(AM_V_at)tar --help|grep -q sort= && taropts="--sort=name --clamp-mtime --format=gnu --owner=0 --group=0" ; tar -c $$taropts --directory $(srcdir)/dot_cardpeek_dir --exclude=.svn --exclude='\._*' . | gzip -cn9 > dot_cardpeek.tar.gz
 
 cardpeek_resources.$(OBJEXT):	dot_cardpeek.tar.gz $(ICONS) AUTHORS COPYING cardpeek_resources.gresource.xml
 			@echo "  GLIB_COMPILE_RESOURCES cardpeek_resources.gresource.xml"


### PR DESCRIPTION
Create tar.gz in a reproducible way
by sorting entries, overriding UID, mtime
and using gzip -n to not add a timestamp in .gz header

See https://reproducible-builds.org/ for why this is good.