### PR TITLE
Let tachograph.lua work with lua5.3 while being backwards compatible.

### DIFF
--- a/dot_cardpeek_dir/scripts/lib/apdu.lua
+++ b/dot_cardpeek_dir/scripts/lib/apdu.lua
@@ -113,7 +113,7 @@ function card.tree_startup(title)
 
 	atrnode = mycard:append({ classname="atr",
 			          label="cold ATR",
-			  	  size=#atr,
+			  	  size=math.tointeger(#atr),
 				  val=atr })
 
 	if candidates then

--- a/dot_cardpeek_dir/scripts/tachograph.lua
+++ b/dot_cardpeek_dir/scripts/tachograph.lua
@@ -105,7 +105,7 @@ function Count_NoOfEventsPerType()
 end
 
 function Count_ActivityStructureLength()
-    return activityStructureLength 
+    return math.tointeger(activityStructureLength) 
 end
 
 function Count_NoOfCardVehicleRecords()
@@ -306,7 +306,7 @@ function Tacho_DATEF(data,node)
 end
 
 function Tacho_NUMERIC(data,node)
-    node:set_attribute("alt",data:tonumber())
+    node:set_attribute("alt",math.tointeger(data:tonumber()))
 end
 
 function Tacho_REGION_NUMERIC(data,node)
@@ -413,15 +413,15 @@ function Tacho_ACTIVITY_RECORDS(data,node)
         local cat_cur = 0
         local rec_date = os.date("!%d/%m/%Y", subpart(data,ptr+4,ptr+7):tonumber())
 
-        subnode = node:append({classname='record',label='CardActivityDailyRecord', size=rec_len, id=counter})
+        subnode = node:append({classname='record',label='CardActivityDailyRecord', size=math.tointeger(rec_len), id=counter})
         subnode:append({classname='item',
                         label='activityRecordLength',
                         val=subpart(data,ptr+2,ptr+3),
-                        alt=string.format("%d (address:%s)",rec_len,ptr)})
+                        alt=string.format("%d (address:%s)",rec_len,math.tointeger(ptr))})
         subnode:append({classname='item',
                         label='activityPreviousRecordLength',
                         val=subpart(data,ptr,ptr+1),
-                        alt=subpart(data,ptr,ptr+1):tonumber()})
+                        alt=math.tointeger(subpart(data,ptr,ptr+1):tonumber())})
         subnode:append({classname='item',
                         label='activityRecordDate',
                         val=subpart(data,ptr+4,ptr+7),
@@ -429,14 +429,14 @@ function Tacho_ACTIVITY_RECORDS(data,node)
         subnode:append({classname='item',
                         label='dailyPresenceCounter',
                         val=subpart(data,ptr+8,ptr+9),
-                        alt=subpart(data,ptr+8,ptr+9):tonumber() })
+                        alt=math.tointeger(subpart(data,ptr+8,ptr+9):tonumber()) })
         subnode:append({classname='item',
                         label='activityDayDistance',
                         val=subpart(data,ptr+10,ptr+11),
-                        alt=subpart(data,ptr+10,ptr+11):tonumber() .. " km"})
+                        alt=math.tointeger(subpart(data,ptr+10,ptr+11):tonumber()) .. " km"})
         subsub_node = subnode:append({classname='record',
                         label='activityChangeInfo',
-                        size=#activity,
+                        size=math.tointeger(#activity),
                         val=activity})
 
         if #activity>0 then

--- a/dot_cardpeek_dir/scripts/tachograph.lua
+++ b/dot_cardpeek_dir/scripts/tachograph.lua
@@ -281,9 +281,10 @@ end
 
 function Tacho_TEXT_8859(data,node)
     global('iconv')
+    local part = math.tointeger(data[0])
     
-    if iconv and data[0]>0 then
-        local format = "ISO-8859-"..data[0]
+    if iconv and part>0 then
+        local format = "ISO-8859-"..part
         local conversion = iconv.open(format,"UTF-8")
         local converted = conversion:iconv(data:sub(1):format("%C"))
         if converted then
@@ -292,9 +293,9 @@ function Tacho_TEXT_8859(data,node)
         end
     end
     
-    if data[0]==1 then
+    if part==1 then
         node:set_attribute("alt",data:sub(1):format("%P"))
-    elseif data[0]==0 then
+    elseif part==0 then
         node:set_attribute("alt","(empty)")
     end
 end 
@@ -327,7 +328,7 @@ function Tacho_ActivityChangeInfo(data,node)
     local time = bit.AND(data:tonumber(),0x07FF)
     local sub_node = node:append({  classname='record',
                                     label='Change', 
-                                    id=string.format("%02u:%02u",time/60,time%60),
+                                    id=string.format("%02u:%02u",math.floor(time/60),time%60),
                                     val=data,
                                     size=2 })
     local activity = bit.SHR(bit.AND(data[0],0x18),3)
@@ -452,10 +453,10 @@ function Tacho_ACTIVITY_RECORDS(data,node)
             subnode:set_attribute("alt",string.format("%s: %d km\n  %dh%02d break, %dh%02d availability, %dh%02d work, %dh%02d drive",
                     rec_date,
                     subpart(data,ptr+10,ptr+11):tonumber(),
-                    cat_total[1]/60,  cat_total[1]%60,
-                    cat_total[2]/60,  cat_total[2]%60,
-                    cat_total[3]/60,  cat_total[3]%60,
-                    cat_total[4]/60,  cat_total[4]%60))
+                    math.floor(cat_total[1]/60),  cat_total[1]%60,
+                    math.floor(cat_total[2]/60),  cat_total[2]%60,
+                    math.floor(cat_total[3]/60),  cat_total[3]%60,
+                    math.floor(cat_total[4]/60),  cat_total[4]%60))
         else
              subnode:set_attribute("alt","(no activity)")
         end         


### PR DESCRIPTION
This just makes the necesarry changes to apdu.lua and tachograph.lua to work with Lua 5.3 and also maintain the same output.

Signed-off-by: David Santamaría Rogado <howl.nsp@gmail.com>