### PR TITLE
fix AC interpreted value

### DIFF
--- a/dot_cardpeek_dir/scripts/gsm (beta).lua
+++ b/dot_cardpeek_dir/scripts/gsm (beta).lua
@@ -56,10 +56,6 @@ BCD_EXTENDED = { "0", "1", "2", "3",
 AC_GSM = { "Always", "CHV1", "CHV2", "RFU", 
 	   "ADM", "ADM", "ADM", "ADM",
 	   "ADM", "ADM", "ADM", "ADM",
-	   "ADM", "ADM", "ADM", "ADM",
-	   "ADM", "ADM", "ADM", "ADM",
-	   "ADM", "ADM", "ADM", "ADM",
-	   "ADM", "ADM", "ADM", "ADM",
 	   "ADM", "ADM", "ADM", "Never" }
 
 MAP1_FILE_STRUCT 	= { [0]="transparent", [1]="linear fixed", [3]="cyclic" }


### PR DESCRIPTION
Since `GSM_access_conditions()` uses an index with a value that can only be between 0x0 and 0xf, the `AC_GSM array` must have 16 entries and not 32. The access condition ‘never’ is therefore never displayed. This patch corrects this.